### PR TITLE
add missing packages for UI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,15 +47,17 @@ RUN curl -LO https://github.com/Medium/phantomjs/releases/download/v$PHANTOM_VER
   chmod +x /usr/bin/phantomjs && \
   rm -rf phantomjs-$PHANTOM_VERSION-linux-x86_64 phantomjs-$PHANTOM_VERSION-linux-x86_64.tar.bz2
 
+RUN yum groupinstall -y 'Development Tools'
+
 RUN yum update -y && \
-  yum install -y make curl-devel expat-devel gettext-devel openssl-devel zlib-devel gcc perl-ExtUtils-MakeMaker
+  yum install -y make curl-devel expat-devel gettext-devel openssl-devel zlib-devel gcc perl-ExtUtils-MakeMaker gcc-c++
 
 RUN curl -L https://www.kernel.org/pub/software/scm/git/git-2.8.3.tar.gz | tar xzv && \
   pushd git-2.8.3 && \
   make prefix=/usr/ install && \
   popd && \
   rm -rf git-2.8.3* && \
-  yum remove -y make curl-devel expat-devel gettext-devel openssl-devel zlib-devel gcc perl-ExtUtils-MakeMaker && \
+  yum remove -y make curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker && \
   yum clean all
 
 RUN npm install -g jasmine-node protractor


### PR DESCRIPTION
This builder image is being used inside fabric8-planner builds.
Jenkins file https://github.com/fabric8-ui/fabric8-planner/blob/master/Jenkinsfile#L14 --> groovy script https://github.com/fabric8io/fabric8-pipeline-library/blob/master/vars/fabric8UITemplate.groovy#L9 --> https://hub.docker.com/r/fabric8/fabric8-ui-builder/tags/

and fabric8-planner builds are showing an error on console e.g> https://jenkins.cd.test.fabric8.io/job/fabric8-ui/job/fabric8-planner/job/master/129/consoleFull
```
make: Entering directory `/home/jenkins/workspace/8-ui_fabric8-planner_master-ZPP4IZOIOGZC2EHZQQ2O5PEN76546POVNRCE6JLDNBSQQFFN5RDA@2/node_modules/integer/build'
  CXX(target) Release/obj.target/integer/src/integer.o
make: g++: Command not found
make: *** [Release/obj.target/integer/src/integer.o] Error 127
make: Leaving directory `/home/jenkins/workspace/8-ui_fabric8-planner_master-ZPP4IZOIOGZC2EHZQQ2O5PEN76546POVNRCE6JLDNBSQQFFN5RDA@2/node_modules/integer/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
```
So I feel that we are missing few packages and need to install them. 
Following are packages we need to run the build smoothly
 - groupinstall 'Development Tools'
 - gcc-c++"

Ref:
https://github.com/facebook/react/issues/3744#issuecomment-193105455
https://unix.stackexchange.com/a/32439

Once merged I hope to see the changes in fabric8-cd whenever I use `container('ui')` in my Jenkins file